### PR TITLE
Fix calculation of b variable in LLK optimization

### DIFF
--- a/src/VerifyBamID.h
+++ b/src/VerifyBamID.h
@@ -433,7 +433,7 @@ class VerifyBamID {
       }
       else if ( minIdx == (int)lks.size()-1 ) {
 	a = 0; fa = f(0);
-	b = (1.-alphas.back())/2.; fb = f(b);
+	b = 1. - (1.-alphas.back())/2.; fb = f(b);
 	c = 1.-alphas.back(); fc = lks.back();
       }
       else {
@@ -520,7 +520,7 @@ class VerifyBamID {
       }
       else if ( minIdx == (int)lks.size()-1 ) {
 	a = 0.5; fa = f(0.5);
-	b = (0.5-alphas.back())/2.; fb = f(b);
+	b = 0.5 - (0.5-alphas.back())/2.; fb = f(b);
 	c = alphas.back(); fc = lks.back();
       }
       else {


### PR DESCRIPTION
Haley Abel and I have discovered what we think is an error in setting up the inputs to Brent's method during likelihood optimization. This results in cases where instead of a < b < c, you may be passing values to the Brent method where b << a < c. 

When we tested this fix on samples mixed at 50%, we get freemix estimates between 0.45-0.47. Without the fix, we get many estimates around 0.23 - 0.27. 

I can provide log files if it would be helpful.
